### PR TITLE
 Log lottery views via kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Run this command from the top-level directory:
 bin/start
 ```
 
-### To start up Spark in the background
+### To start up Spark, run:
 
 ```bash
-bin/run-spark &
+bin/spark -v
 ```
+
+Leave off the -v flag for quiet output.
 
 ### Drop into MySQL repl
 
@@ -73,3 +75,4 @@ docker-compose exec web bash
 12. As a user, I want new lotteries and cards that I add to show up in the search database so that I know others can find them.
 13. As a user, I want to be able to filter my searches so that I can find specific entries more easily.
 14. As a user, I want the search bar to be accessible at the top of all screens so that I can easily search from anywhere on the site.
+15. As a user, I want to be able to see recommended lotteries based on what lotteries are often accessed together by users.

--- a/batch/log.py
+++ b/batch/log.py
@@ -1,0 +1,30 @@
+import json
+import time
+import os
+
+from kafka import KafkaConsumer
+from kafka.common import NodeNotReadyError
+
+
+def listen(kafka_hook):
+    file_path = '/data/data/views.log'
+    if not os.path.isfile(file_path):
+        open(file_path, 'w').close()
+    for message in kafka_hook:
+        new_view = json.loads(message.value.decode('utf-8'))
+        with open(file_path, 'a') as log:
+            log.write("%s\t%s\n" % (new_view[0], new_view[1]))
+
+
+def try_connect():
+    while True:
+        try:
+            consumer = KafkaConsumer('new_view', group_id='indexer', bootstrap_servers=['kafka:9092'])
+            break
+        except NodeNotReadyError:
+            time.sleep(3)
+
+    listen(consumer)
+
+
+try_connect()

--- a/bin/rm-containers
+++ b/bin/rm-containers
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-docker rm app_web_1
-docker rm app_exp_1
+docker stop $(docker ps -a -q)
 docker rm batch
 docker rm es
 docker rm kafka
-docker rm app_models_1
 docker rm jmeter
 docker rm my-running-haproxy
+docker rm $(docker ps -a -q -f name=app_)

--- a/bin/run-spark
+++ b/bin/run-spark
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-while true; do
-	docker-compose exec spark-master bin/spark-submit --master spark://spark-master:7077 --total-executor-cores 2 --executor-memory 512m /tmp/data/spark.py >/dev/null 2>&1
-	sleep 90
-done

--- a/bin/spark
+++ b/bin/spark
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+while true; do
+	if [ "$1" == "-v" ]; then
+		docker-compose exec spark-master bin/spark-submit --master spark://spark-master:7077 --total-executor-cores 2 --executor-memory 512m /tmp/data/spark.py
+	else
+		docker-compose exec spark-master bin/spark-submit --master spark://spark-master:7077 --total-executor-cores 2 --executor-memory 512m /tmp/data/spark.py >/dev/null 2>&1
+	fi
+	sleep 90
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ web:
    stdin_open: true
    command: bash -c "python manage.py collectstatic --noinput > /dev/null && python manage.py clear_cache > /dev/null && mod_wsgi-express start-server --working-directory . --document-root build --reload-on-changes --log-to-terminal web/wsgi.py"
 
-batch:
+batch-search:
    image: djangorest
    links:
       - kafka
@@ -125,4 +125,13 @@ batch:
    volumes:
       - ./batch:/app
       - ./models:/data
-   command: "python search.py es kafka"
+   command: "python search.py es"
+
+batch-recommend:
+   image: djangorest
+   links:
+      - kafka
+   volumes:
+      - ./batch:/app
+      - ./spark:/data
+   command: "python log.py"

--- a/exp/exp_app/__init__.py
+++ b/exp/exp_app/__init__.py
@@ -40,9 +40,9 @@ def missing_param(body, params):
     return False
 
 
-def kafka_add(listing):
+def kafka_add(topic, listing):
     producer = KafkaProducer(bootstrap_servers='kafka:9092')
-    producer.send('new_listing', dumps(listing).encode('utf-8'))
+    producer.send(topic, dumps(listing).encode('utf-8'))
 
 
 def forward_get(request, model_api, required_params):
@@ -68,6 +68,6 @@ def forward_post(request, model_api, required_data):
 
     if response.ok:
         data['id'] = response.json()['id']
-        kafka_add(data)
+        kafka_add('new_listing', data)
 
     return HttpResponse(status=response.status_code)

--- a/exp/exp_app/urls.py
+++ b/exp/exp_app/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^card-detail/([0-9]+)/?$', views.card_detail, name='card-detail'),
 
     url(r'^lottery-pane/?$', views.lottery_pane, name='lottery-pane'),
-    url(r'^lottery-detail/([0-9]+)/?$', views.lottery_detail, name='lottery-detail'),
+    url(r'^lottery-detail/(?P<pk>[0-9]+)/?$', views.lottery_detail, name='lottery-detail'),
     url(r'^lottery-create/?$', views.lottery_create, name='lottery-create'),
 
     url(r'^search/?$', views.search, name='search'),

--- a/models/models_app/models.py
+++ b/models/models_app/models.py
@@ -26,6 +26,7 @@ class Authenticator(models.Model):
         return {
             'authenticator': self.authenticator,
             'username': person.username,
+            'id': person.id,
             'first_name': person.first_name,
             'last_name': person.last_name,
             'currency': person.currency,

--- a/spark/data/spark.py
+++ b/spark/data/spark.py
@@ -2,7 +2,7 @@ from pyspark import SparkContext
 import itertools
 
 
-DEBUG = False
+DEBUG = True
 
 
 def test(rdd):
@@ -18,9 +18,9 @@ def test(rdd):
         print('----------------------------------------------------------')
 
 
-sc = SparkContext("spark://spark-master:7077", "PopularItems")
+sc = SparkContext("spark://spark-master:7077", "CoViews")
 
-data = sc.textFile("/tmp/data/test.log", 2)     # each worker loads a piece of the data file
+data = sc.textFile("/tmp/data/views.log", 2)     # each worker loads a piece of the data file
 
 # tab separated log file => (user_id, product_id)
 user_to_prod = data.map(lambda line: tuple(line.split("\t")))
@@ -62,6 +62,9 @@ if DEBUG:
 
 # filter out pairs with fewer than 3 clicks
 final_counts = prod_pair_to_clicks.filter(lambda row: row[1] >= 3)
+
+if DEBUG:
+    test(final_counts)
 
 # key value pairs of the form ((product_id_1, product_id_2), int holding unique clicks)
 output = final_counts.collect()

--- a/web/web_app/views.py
+++ b/web/web_app/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.views.decorators.cache import never_cache
 from django.views.decorators.vary import vary_on_cookie
 
 from . import get, post, fill_defaults
@@ -100,9 +101,13 @@ def card_create(request):
     return render(request, 'card-create.html', context)
 
 
-@vary_on_cookie
+@never_cache
 def lottery_detail(request, pk):
-    lottery_details = get('lottery-detail', pk)
+    if hasattr(request.user, 'id'):
+        user_id = request.user.id
+    else:
+        user_id = ''
+    lottery_details = get('lottery-detail', pk, params={'user_id': user_id})
     if not lottery_details:
         return HttpResponseRedirect(reverse('lotteries'))
     return render(request, 'lottery-detail.html', lottery_details)


### PR DESCRIPTION
- add new docker container to run batch file with kafka consumer that logs visits to lottery_detail
- only logs lottery_detail views for logged in users
- make spark script quiet by default, with a flag for output (-v)
- make the rm-containers script i wrote not useless